### PR TITLE
moved from PyQt5 to Pyside2 #2, updated Pillow and vtk

### DIFF
--- a/Controller/controller.py
+++ b/Controller/controller.py
@@ -22,9 +22,9 @@
     SOFTWARE.
 """
 
-from PyQt5.QtCore import QObject
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QFileDialog
+from PySide2.QtCore import QObject
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QFileDialog
 from Core.messages import StateMsg
 from Core.messages import ViewMode
 from Core.socket_stream import SocketStream
@@ -77,7 +77,7 @@ class Controller(QObject):
     def indices(self):
         return self._indices
 
-    @pyqtSlot(tuple, name='handle_state_msg')
+    @Slot(tuple, name='handle_state_msg')
     def handle_state_msg(self, tpl):
         """
         Handle current state, messages mostly received from thread,
@@ -198,7 +198,7 @@ class Controller(QObject):
             if plugin:
                 plugin.update_view()
 
-    @pyqtSlot(bool, name='handle_disconnect')
+    @Slot(bool, name='handle_disconnect')
     def handle_disconnect(self, disconnected):
         """
         Disconnects the client from the server
@@ -601,7 +601,7 @@ class Controller(QObject):
                 options.set_option_auto_image_load(options_dict['auto_rendered_image_load'])
             # restart application if user user presses ok
             if theme_changed:
-                from PyQt5.QtWidgets import QMessageBox
+                from PySide2.QtWidgets import QMessageBox
                 retval = self._view.view_popup.restart_application_info("Theme change in progress ...")
                 if retval == QMessageBox.Ok:
                     options.set_theme(options_dict['theme'])

--- a/Core/hdr_graphics_view_base.py
+++ b/Core/hdr_graphics_view_base.py
@@ -23,11 +23,11 @@
 """
 
 from Core.hdr_image import HDRImage
-from PyQt5.QtWidgets import QGraphicsPixmapItem
-from PyQt5.QtWidgets import QGraphicsScene
-from PyQt5.QtWidgets import QGraphicsView
-from PyQt5.QtCore import QPoint
-from PyQt5.QtCore import Qt
+from PySide2.QtWidgets import QGraphicsPixmapItem
+from PySide2.QtWidgets import QGraphicsScene
+from PySide2.QtWidgets import QGraphicsView
+from PySide2.QtCore import QPoint
+from PySide2.QtCore import Qt
 import math
 import logging
 

--- a/Core/hdr_image.py
+++ b/Core/hdr_image.py
@@ -26,7 +26,7 @@ import OpenEXR
 import Imath
 from PIL import Image
 from PIL.ImageQt import ImageQt as PilImageQt
-from PyQt5.QtGui import QPixmap
+from PySide2.QtGui import QPixmap
 from enum import Enum
 import array
 import numpy as np

--- a/Core/plot_figure_base.py
+++ b/Core/plot_figure_base.py
@@ -25,8 +25,8 @@
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolBar
-from PyQt5.QtWidgets import QSizePolicy
-from PyQt5.QtCore import Qt
+from PySide2.QtWidgets import QSizePolicy
+from PySide2.QtCore import Qt
 import numpy as np
 import logging
 

--- a/Core/plugin.py
+++ b/Core/plugin.py
@@ -22,7 +22,7 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QWidget
+from PySide2.QtWidgets import QWidget
 import abc
 
 

--- a/Core/pyside2_uic.py
+++ b/Core/pyside2_uic.py
@@ -1,0 +1,140 @@
+from PySide2.QtCore import QMetaObject
+from PySide2.QtUiTools import QUiLoader
+
+
+# Source: https://github.com/spyder-ide/qtpy/blob/d53db43e11200ee9324f399504c8a97d2432658c/qtpy/uic.py
+
+
+class UiLoader(QUiLoader):
+    """
+    Subclass of :class:`~PySide.QtUiTools.QUiLoader` to create the user
+    interface in a base instance.
+    Unlike :class:`~PySide.QtUiTools.QUiLoader` itself this class does not
+    create a new instance of the top-level widget, but creates the user
+    interface in an existing instance of the top-level class if needed.
+    This mimics the behaviour of :func:`PyQt4.uic.loadUi`.
+    """
+
+    def __init__(self, baseinstance, customWidgets=None):
+        """
+        Create a loader for the given ``baseinstance``.
+        The user interface is created in ``baseinstance``, which must be an
+        instance of the top-level class in the user interface to load, or a
+        subclass thereof.
+        ``customWidgets`` is a dictionary mapping from class name to class
+        object for custom widgets. Usually, this should be done by calling
+        registerCustomWidget on the QUiLoader, but with PySide 1.1.2 on
+        Ubuntu 12.04 x86_64 this causes a segfault.
+        ``parent`` is the parent object of this loader.
+        """
+
+        QUiLoader.__init__(self, baseinstance)
+
+        self.baseinstance = baseinstance
+
+        if customWidgets is None:
+            self.customWidgets = {}
+        else:
+            self.customWidgets = customWidgets
+
+    def createWidget(self, class_name, parent=None, name=''):
+        """
+        Function that is called for each widget defined in ui file,
+        overridden here to populate baseinstance instead.
+        """
+
+        if parent is None and self.baseinstance:
+            # supposed to create the top-level widget, return the base
+            # instance instead
+            return self.baseinstance
+
+        else:
+
+            # For some reason, Line is not in the list of available
+            # widgets, but works fine, so we have to special case it here.
+            if class_name in self.availableWidgets() or class_name == 'Line':
+                # create a new widget for child widgets
+                widget = QUiLoader.createWidget(self, class_name, parent, name)
+
+            else:
+                # If not in the list of availableWidgets, must be a custom
+                # widget. This will raise KeyError if the user has not
+                # supplied the relevant class_name in the dictionary or if
+                # customWidgets is empty.
+                try:
+                    widget = self.customWidgets[class_name](parent)
+                except KeyError:
+                    raise Exception('No custom widget ' + class_name + ' '
+                                                                       'found in customWidgets')
+
+            if self.baseinstance:
+                # set an attribute for the new child widget on the base
+                # instance, just like PyQt4.uic.loadUi does.
+                setattr(self.baseinstance, name, widget)
+
+            return widget
+
+
+def _get_custom_widgets(ui_file):
+    """
+    This function is used to parse a ui file and look for the <customwidgets>
+    section, then automatically load all the custom widget classes.
+    """
+
+    import sys
+    import importlib
+    from xml.etree.ElementTree import ElementTree
+
+    # Parse the UI file
+    etree = ElementTree()
+    ui = etree.parse(ui_file)
+
+    # Get the customwidgets section
+    custom_widgets = ui.find('customwidgets')
+
+    if custom_widgets is None:
+        return {}
+
+    custom_widget_classes = {}
+
+    for custom_widget in custom_widgets.getchildren():
+        cw_class = custom_widget.find('class').text
+        cw_header = custom_widget.find('header').text
+
+        module = importlib.import_module(cw_header)
+
+        custom_widget_classes[cw_class] = getattr(module, cw_class)
+
+    return custom_widget_classes
+
+
+def loadUi(uifile, baseinstance=None, workingDirectory=None):
+    """
+    Dynamically load a user interface from the given ``uifile``.
+    ``uifile`` is a string containing a file name of the UI file to load.
+    If ``baseinstance`` is ``None``, the a new instance of the top-level
+    widget will be created. Otherwise, the user interface is created within
+    the given ``baseinstance``. In this case ``baseinstance`` must be an
+    instance of the top-level widget class in the UI file to load, or a
+    subclass thereof. In other words, if you've created a ``QMainWindow``
+    interface in the designer, ``baseinstance`` must be a ``QMainWindow``
+    or a subclass thereof, too. You cannot load a ``QMainWindow`` UI file
+    with a plain :class:`~PySide.QtGui.QWidget` as ``baseinstance``.
+    :method:`~PySide.QtCore.QMetaObject.connectSlotsByName()` is called on
+    the created user interface, so you can implemented your slots according
+    to its conventions in your widget class.
+    Return ``baseinstance``, if ``baseinstance`` is not ``None``. Otherwise
+    return the newly created instance of the user interface.
+    """
+
+    # We parse the UI file and import any required custom widgets
+    customWidgets = _get_custom_widgets(uifile)
+
+    loader = UiLoader(baseinstance, customWidgets)
+
+    if workingDirectory is not None:
+        loader.setWorkingDirectory(workingDirectory)
+
+    widget = loader.load(uifile)
+    QMetaObject.connectSlotsByName(widget)
+    return widget

--- a/Core/socket_stream_backend.py
+++ b/Core/socket_stream_backend.py
@@ -22,10 +22,10 @@
     SOFTWARE.
 """
 
-from PyQt5.QtCore import QThread
+from PySide2.QtCore import QThread
 from Core.messages import ServerMsg
 from Core.messages import StateMsg
-from PyQt5.QtCore import pyqtSignal
+from PySide2.QtCore import Signal
 import logging
 
 
@@ -38,7 +38,7 @@ class SocketStreamBackend(QThread):
     Incoming data is deserialized within this thread.
     """
 
-    _sendStateMsgSig = pyqtSignal(tuple)
+    _sendStateMsgSig = Signal(tuple)
 
     def __init__(self, stream, controller, model, parent=None):
         QThread.__init__(self, parent=parent)

--- a/CustomData/custom_data_base.py
+++ b/CustomData/custom_data_base.py
@@ -22,7 +22,7 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QTreeWidgetItem
+from PySide2.QtWidgets import QTreeWidgetItem
 import logging
 import abc
 

--- a/Model/dataset.py
+++ b/Model/dataset.py
@@ -33,8 +33,8 @@ from Model.plot_data import FinalEstimate
 from Model.detector import Detector
 from Model.pixel_info import PixelInfo
 from Model.filter import Filter
-from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtCore import QObject
+from PySide2.QtCore import Signal
+from PySide2.QtCore import QObject
 from Core.messages import StateMsg
 import time
 import logging
@@ -49,7 +49,7 @@ class Dataset(QObject):
         Therefore deserializes the data from the socket stream or xml file.
     """
 
-    sendStateMsgSig = pyqtSignal(tuple)
+    sendStateMsgSig = Signal(tuple)
 
     def __init__(self):
         QObject.__init__(self, parent=None)

--- a/Model/pixel_info.py
+++ b/Model/pixel_info.py
@@ -25,11 +25,11 @@
 from Types.factory import TypeFactory
 from Types.point2 import Point2i
 from Types.color3 import Color3f
-from PyQt5.QtGui import QPixmap
-from PyQt5.QtGui import QImage
-from PyQt5.QtGui import QColor
-from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import QPoint
+from PySide2.QtGui import QPixmap
+from PySide2.QtGui import QImage
+from PySide2.QtGui import QColor
+from PySide2.QtGui import QIcon
+from PySide2.QtCore import QPoint
 import logging
 
 
@@ -103,7 +103,8 @@ class PixelInfo(object):
         :return:
         """
         self._pixel_pos = pixel
-        self._color = QColor(QImage(pixmap).pixel(pixel.x(), pixel.y()))
+        q_image = pixmap.toImage()
+        self._color = q_image.pixelColor(pixel)
         self._pixmap.fill(self._color)
         self._pixel_icon.addPixmap(self._pixmap)
 

--- a/Plugins/PathDepth/plugin_path_depth.py
+++ b/Plugins/PathDepth/plugin_path_depth.py
@@ -24,7 +24,7 @@
 
 from Core.plugin import Plugin
 from Plugins.PathDepth.plot_path_depth import PlotPathDepth
-from PyQt5.QtWidgets import QVBoxLayout
+from PySide2.QtWidgets import QVBoxLayout
 
 
 class PathDepth(Plugin):

--- a/Plugins/SphericalView/plugin_spherical_view.py
+++ b/Plugins/SphericalView/plugin_spherical_view.py
@@ -25,7 +25,7 @@
 from Core.plugin import Plugin
 from Plugins.SphericalView.view_spherical_view_image import ViewSphericalViewImage
 from Types.point2 import Point2i
-from PyQt5 import uic
+from Core.pyside2_uic import loadUi
 import io
 import os
 import logging
@@ -39,7 +39,7 @@ class SphericalView(Plugin):
             "SphericalView",
             66)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), 'ui', 'spherical_view.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._path = None
         self._render_data = None

--- a/Plugins/SphericalView/spherical_graphics_view.py
+++ b/Plugins/SphericalView/spherical_graphics_view.py
@@ -23,11 +23,11 @@
 """
 
 from Core.hdr_graphics_view_base import HDRGraphicsViewBase
-from PyQt5.QtWidgets import QFileDialog
-from PyQt5.QtGui import QBrush
-from PyQt5.QtGui import QColor
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import QPoint
+from PySide2.QtWidgets import QFileDialog
+from PySide2.QtGui import QBrush
+from PySide2.QtGui import QColor
+from PySide2.QtCore import Qt
+from PySide2.QtCore import QPoint
 import logging
 
 import matplotlib.pyplot as plt

--- a/Plugins/SphericalView/view_spherical_view_image.py
+++ b/Plugins/SphericalView/view_spherical_view_image.py
@@ -23,10 +23,10 @@
 """
 
 from Plugins.SphericalView.spherical_graphics_view import SphericalGraphicsView
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import Qt
-from PyQt5.QtCore import pyqtSlot
-from PyQt5 import uic
+from PySide2.QtWidgets import QWidget
+from PySide2.QtCore import Qt
+from PySide2.QtCore import Slot
+from Core.pyside2_uic import loadUi
 import os
 import logging
 
@@ -40,7 +40,7 @@ class ViewSphericalViewImage(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=parent)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), 'ui', 'spherical_view_image.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._pos = None
         self._dirW_i = None
@@ -63,19 +63,19 @@ class ViewSphericalViewImage(QWidget):
         self.falsecolorCb.toggled.connect(self.falsecolor_cb)
         self.exposureSlider.valueChanged.connect(self.exposure_slider)
 
-    @pyqtSlot(bool, name='save_image')
+    @Slot(bool, name='save_image')
     def save_image(self, clicked):
         self._graphics_view.save_image()
 
-    @pyqtSlot(bool, name='fit_view')
+    @Slot(bool, name='fit_view')
     def fit_view(self, clicked):
         self._graphics_view.reset()
 
-    @pyqtSlot(bool, name='falsecolor_cb')
+    @Slot(bool, name='falsecolor_cb')
     def falsecolor_cb(self, checked):
         self.falsecolor = checked
 
-    @pyqtSlot(int, name='exposure_slider')
+    @Slot(int, name='exposure_slider')
     def exposure_slider(self, value):
         self.exposure = float(value)/100.0
 

--- a/Plugins/VertexDataPlots/hist_list_item.py
+++ b/Plugins/VertexDataPlots/hist_list_item.py
@@ -22,7 +22,7 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QListWidgetItem
+from PySide2.QtWidgets import QListWidgetItem
 
 
 class HistListItem(QListWidgetItem):

--- a/Plugins/VertexDataPlots/plugin_vertex_data_plots.py
+++ b/Plugins/VertexDataPlots/plugin_vertex_data_plots.py
@@ -24,11 +24,11 @@
 
 from Core.plugin import Plugin
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QVBoxLayout
-from PyQt5.QtWidgets import QListWidgetItem
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtCore import Qt
+from Core.pyside2_uic import loadUi
+from PySide2.QtWidgets import QVBoxLayout
+from PySide2.QtWidgets import QListWidgetItem
+from PySide2.QtCore import Slot
+from PySide2.QtCore import Qt
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolBar
 
 from Plugins.VertexDataPlots.hist_list_item import HistListItem
@@ -56,7 +56,7 @@ class VertexDataPlots(Plugin):
             self,
             name='Vertex Data Plots',
             flag=27)
-        uic.loadUi('Plugins/VertexDataPlots/ui/plugin_plots.ui', self)
+        loadUi('Plugins/VertexDataPlots/ui/plugin_plots.ui', self)
 
         self._vertex_data_plot_2d = VertexDataPlot2D(self)
         self._vertex_data_plot_3d = VertexDataPlot3D(self)
@@ -133,11 +133,11 @@ class VertexDataPlots(Plugin):
             elif stacked_idx == 2:
                 self._vertex_data_plot_rgb.select_vertex(tpl)
 
-    @pyqtSlot(QListWidgetItem, name='apply_path_index_update')
+    @Slot(QListWidgetItem, name='apply_path_index_update')
     def apply_path_index_update(self, item):
         self.send_select_path(item.idx)
 
-    @pyqtSlot(QListWidgetItem, name='update_hist_path')
+    @Slot(QListWidgetItem, name='update_hist_path')
     def update_hist_path(self, item):
         self.listHistNames.clear()
         if not item:

--- a/PluginsHandler/plugins_view_container.py
+++ b/PluginsHandler/plugins_view_container.py
@@ -22,12 +22,12 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QPushButton
-from PyQt5.QtWidgets import QVBoxLayout
-from PyQt5.QtWidgets import QHBoxLayout
-from PyQt5.QtWidgets import QFrame
-from PyQt5.QtCore import pyqtSlot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QPushButton
+from PySide2.QtWidgets import QVBoxLayout
+from PySide2.QtWidgets import QHBoxLayout
+from PySide2.QtWidgets import QFrame
+from PySide2.QtCore import Slot
 import logging
 
 
@@ -209,7 +209,7 @@ class PluginsViewContainer(QWidget):
         """
         self._plugin.update_view()
 
-    @pyqtSlot(bool, name='request_plugin')
+    @Slot(bool, name='request_plugin')
     def request_plugin(self, clicked):
         """
         Calls the controller request_tool function.
@@ -220,7 +220,7 @@ class PluginsViewContainer(QWidget):
         """
         self._controller.request_plugin(self._plugin.flag)
 
-    @pyqtSlot(bool, name='display_tool')
+    @Slot(bool, name='display_tool')
     def display_plugin(self, clicked):
         """
         Opens and displays the tool window,

--- a/Renderer/renderer.py
+++ b/Renderer/renderer.py
@@ -29,7 +29,7 @@ from Renderer.meshes import Meshes
 from Renderer.camera import Camera
 from Renderer.path import Path
 from Renderer.vertex import Vertex
-from PyQt5.QtWidgets import QFrame
+from PySide2.QtWidgets import QFrame
 import vtk
 import time
 import logging

--- a/Resources/breeze_resources.py
+++ b/Resources/breeze_resources.py
@@ -6,7 +6,7 @@
 #
 # WARNING! All changes made in this file will be lost!
 
-from PyQt5 import QtCore
+from PySide2 import QtCore
 
 qt_resource_data = b"\
 \x00\x00\x13\xe6\

--- a/View/DataView/tree_node_items.py
+++ b/View/DataView/tree_node_items.py
@@ -22,7 +22,7 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QTreeWidgetItem
+from PySide2.QtWidgets import QTreeWidgetItem
 
 
 class PathNodeItem(QTreeWidgetItem):

--- a/View/DataView/view_render_data.py
+++ b/View/DataView/view_render_data.py
@@ -25,12 +25,12 @@
 from View.DataView.tree_node_items import PathNodeItem
 from View.DataView.tree_node_items import VertexNodeItem
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QTreeWidgetItem
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QAbstractItemView
+from Core.pyside2_uic import loadUi
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QTreeWidgetItem
+from PySide2.QtCore import Slot
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QAbstractItemView
 import numpy as np
 import os
 import logging
@@ -47,7 +47,7 @@ class ViewRenderData(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=parent)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'render_data.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self.tree.setHeaderLabels(["Item", "Value"])
         self.tree.setColumnWidth(0, 200)
@@ -80,7 +80,7 @@ class ViewRenderData(QWidget):
         """
         self._selected_indices = np.append(self._selected_indices, index)
 
-    @pyqtSlot(QTreeWidgetItem, QTreeWidgetItem, name='select_tree_item')
+    @Slot(QTreeWidgetItem, QTreeWidgetItem, name='select_tree_item')
     def select_tree_item(self, item, previous):
         """
         Handles if a path or vertex node is selected. Informs the controller about the selected index
@@ -113,7 +113,7 @@ class ViewRenderData(QWidget):
 
         self._handling_selection_signal = True
 
-    @pyqtSlot(bool, name='show_all_data')
+    @Slot(bool, name='show_all_data')
     def show_all_data(self, clicked):
         """
         Handles the button input of show all data,
@@ -125,7 +125,7 @@ class ViewRenderData(QWidget):
             indices = self._render_data.get_indices()
             self._controller.update_path(indices, False)
 
-    @pyqtSlot(bool, name='inspect_selected_paths')
+    @Slot(bool, name='inspect_selected_paths')
     def inspect_selected_paths(self, clicked):
         """
         Handles the button input of inspect,
@@ -144,7 +144,7 @@ class ViewRenderData(QWidget):
                 elif isinstance(item, VertexNodeItem):
                     self._controller.update_path(np.array([item.parent_index]), False)
 
-    @pyqtSlot(bool, name='expand_items')
+    @Slot(bool, name='expand_items')
     def expand_items(self, state):
         """
         Depending on state, expands the tree view and shows all child items.

--- a/View/MainView/main_view.py
+++ b/View/MainView/main_view.py
@@ -22,10 +22,10 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtWidgets import QMainWindow
-from PyQt5.QtWidgets import QAction
-from PyQt5.QtCore import pyqtSlot
+from PySide2.QtWidgets import QApplication
+from PySide2.QtWidgets import QMainWindow
+from PySide2.QtWidgets import QAction
+from PySide2.QtCore import Slot
 from View.MainView.view_emca import ViewEMCA
 from View.MainView.popup_messages import PopupMessages
 from View.MainView.view_options import ViewOptions
@@ -137,7 +137,7 @@ class MainView(QMainWindow):
         """
         self._view_emca.btnFilter.setEnabled(enable)
 
-    @pyqtSlot(bool, name='open_options')
+    @Slot(bool, name='open_options')
     def open_options(self, clicked):
         """
         Opens the options window
@@ -146,7 +146,7 @@ class MainView(QMainWindow):
         """
         self._controller.open_options(clicked)
 
-    @pyqtSlot(bool, name='load_image_dialog')
+    @Slot(bool, name='load_image_dialog')
     def load_image_dialog(self, clicked):
         """
         Opens the dialog to load a file
@@ -155,7 +155,7 @@ class MainView(QMainWindow):
         """
         self._controller.load_image_dialog(clicked)
 
-    @pyqtSlot(bool, name='save_xml')
+    @Slot(bool, name='save_xml')
     def save_xml(self, clicked):
         """
         Opens the dialog to save the render data within a xml file
@@ -164,7 +164,7 @@ class MainView(QMainWindow):
         """
         self._controller.save_xml(clicked)
 
-    @pyqtSlot(bool, name='load_xml')
+    @Slot(bool, name='load_xml')
     def load_xml(self, clicked):
         """
         Opens the dialog to load a xml file with a stored render state
@@ -173,7 +173,7 @@ class MainView(QMainWindow):
         """
         self._controller.load_xml(clicked)
 
-    @pyqtSlot(bool, name='take_screenshot')
+    @Slot(bool, name='take_screenshot')
     def take_screenshot(self, clicked):
         """
         Takes a screenshow of the whole EMCA widget

--- a/View/MainView/popup_messages.py
+++ b/View/MainView/popup_messages.py
@@ -22,8 +22,8 @@
     SOFTWARE.
 """
 
-from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QMessageBox
+from PySide2.QtCore import QObject
+from PySide2.QtWidgets import QMessageBox
 
 
 class PopupMessages(QObject):

--- a/View/MainView/view_connect_settings.py
+++ b/View/MainView/view_connect_settings.py
@@ -22,11 +22,11 @@
     SOFTWARE.
 """
 
-from PyQt5 import uic
-from PyQt5.Qt import Qt
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QApplication
+from Core.pyside2_uic import loadUi
+from PySide2.QtCore import Qt
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QApplication
 import os
 import logging
 
@@ -41,7 +41,7 @@ class ViewConnectSettings(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=None)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'connect.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._controller = None
 
@@ -87,7 +87,7 @@ class ViewConnectSettings(QWidget):
         if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
             self.btn_connect(True)
 
-    @pyqtSlot(bool, name='connect')
+    @Slot(bool, name='connect')
     def btn_connect(self, clicked):
         """
         Informs the controller to connect to the given hostname and port.

--- a/View/MainView/view_detector_settings.py
+++ b/View/MainView/view_detector_settings.py
@@ -22,10 +22,10 @@
     SOFTWARE.
 """
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QApplication
+from Core.pyside2_uic import loadUi
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QApplication
 import os
 import logging
 
@@ -41,7 +41,7 @@ class ViewDetectorSettings(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=None)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'detector.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._controller = None
 
@@ -75,7 +75,7 @@ class ViewDetectorSettings(QWidget):
         self.dsb_pre_filter.setValue(detector.pre_filter)
         self.cb_default.setChecked(detector.is_default_active())
 
-    @pyqtSlot(bool, name='toggle_esd')
+    @Slot(bool, name='toggle_esd')
     def toggle_esd(self, clicked):
         """
         Toggles the checkbox of the ESD detector, only one detector can be active
@@ -87,7 +87,7 @@ class ViewDetectorSettings(QWidget):
         if not self.cb_default.isChecked() and not self.cb_esd.isChecked():
             self.cb_esd.setChecked(True)
 
-    @pyqtSlot(bool, name='toggle_default')
+    @Slot(bool, name='toggle_default')
     def toggle_default(self, clicked):
         """
         Toggles the checkbox of the default detector, only one detector can be active
@@ -99,7 +99,7 @@ class ViewDetectorSettings(QWidget):
         if not self.cb_esd.isChecked() and not self.cb_default.isChecked():
             self.cb_default.setChecked(True)
 
-    @pyqtSlot(bool, name='apply')
+    @Slot(bool, name='apply')
     def apply(self, clicked):
         """
         Informs the controller to apply the current detector settings
@@ -115,7 +115,7 @@ class ViewDetectorSettings(QWidget):
             self.cb_is_active.isChecked()
         )
 
-    @pyqtSlot(bool, name='apply_close')
+    @Slot(bool, name='apply_close')
     def apply_close(self, clicked):
         """
         Applies the current detector by informing the controller and closes the view.

--- a/View/MainView/view_emca.py
+++ b/View/MainView/view_emca.py
@@ -23,12 +23,12 @@
 """
 
 from Core.messages import ViewMode
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QStackedWidget
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtCore import QPoint
-from PyQt5.QtGui import QPixmap
-from PyQt5 import uic
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QStackedWidget
+from PySide2.QtCore import Slot
+from PySide2.QtCore import QPoint
+from PySide2.QtGui import QPixmap
+from Core.pyside2_uic import loadUi
 
 from View.MainView.view_options import ViewOptions
 from View.MainView.view_connect_settings import ViewConnectSettings
@@ -56,7 +56,7 @@ class ViewEMCA(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=parent)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'emca.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self.setAcceptDrops(True)
 
@@ -113,7 +113,7 @@ class ViewEMCA(QWidget):
         self._view_detector.set_controller(controller)
         self._view_filter.set_controller(controller)
 
-    @pyqtSlot(bool, name='open_connect_view')
+    @Slot(bool, name='open_connect_view')
     def open_connect_view(self, clicked):
         """
         Opens the connect view, if the view is already open the window is set back to active
@@ -125,7 +125,7 @@ class ViewEMCA(QWidget):
         else:
             self._view_connect.show()
 
-    @pyqtSlot(bool, name='open_detector_view')
+    @Slot(bool, name='open_detector_view')
     def open_detector_view(self, clicked):
         """
         Opens the detector view, if the view is already open the window is set back to active
@@ -137,7 +137,7 @@ class ViewEMCA(QWidget):
         else:
             self._view_detector.show()
 
-    @pyqtSlot(bool, name='open_filter_view')
+    @Slot(bool, name='open_filter_view')
     def open_filter_view(self, clicked):
         """
         Opens the filter view, if the view is already open the window is set back to active
@@ -149,7 +149,7 @@ class ViewEMCA(QWidget):
         else:
             self._view_filter.show()
 
-    @pyqtSlot(bool, name='open_render_info_view')
+    @Slot(bool, name='open_render_info_view')
     def open_render_info_view(self, clicked):
         """
         Opens the render info view, if the view is already open the window is set back to active
@@ -161,7 +161,7 @@ class ViewEMCA(QWidget):
         else:
             self._view_render_info.show()
 
-    @pyqtSlot(bool, name='request_render_image')
+    @Slot(bool, name='request_render_image')
     def request_render_image(self, clicked):
         """
         Informs the controller to request the render image from the server
@@ -170,7 +170,7 @@ class ViewEMCA(QWidget):
         """
         self._controller.request_render_image()
 
-    @pyqtSlot(bool, name='toggle_view_left')
+    @Slot(bool, name='toggle_view_left')
     def toggle_view_left(self, clicked):
         """
         Toggles the two views on the left side 2D and 3D view via a stacked widget
@@ -187,7 +187,7 @@ class ViewEMCA(QWidget):
             self.btn2D3DView.setText('Scene View')
             self._stacked_widget_left.setCurrentIndex(0)
 
-    @pyqtSlot(bool, name='toggle_view_right')
+    @Slot(bool, name='toggle_view_right')
     def toggle_view_right(self, clicked):
         """
         Toggles the two views on the right side final estimate plot and render data via a stacked widget
@@ -356,7 +356,7 @@ class ViewEMCA(QWidget):
             self.cbPixelHistory.setCurrentIndex(idx)
         self.cbPixelHistory.blockSignals(False)
 
-    @pyqtSlot(int, name='request_history_pixel')
+    @Slot(int, name='request_history_pixel')
     def request_history_pixel(self, index):
         """
         Informs the controller to request an old data set from the pixel history

--- a/View/MainView/view_filter.py
+++ b/View/MainView/view_filter.py
@@ -22,14 +22,14 @@
     SOFTWARE.
 """
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QFormLayout
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtWidgets import QListWidgetItem
-from PyQt5.QtWidgets import QLabel
-from PyQt5.QtCore import Qt
+from Core.pyside2_uic import loadUi
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QFormLayout
+from PySide2.QtWidgets import QApplication
+from PySide2.QtWidgets import QListWidgetItem
+from PySide2.QtWidgets import QLabel
+from PySide2.QtCore import Qt
 
 from Types.point2 import Point2f
 from Types.point2 import Point2i
@@ -254,7 +254,7 @@ class ViewFilter(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=None)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'filter.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._controller = None
 
@@ -376,7 +376,7 @@ class ViewFilter(QWidget):
         if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
             self.add_filter(True)
 
-    @pyqtSlot(str, name='update_stacked_widget')
+    @Slot(str, name='update_stacked_widget')
     def update_stacked_widget(self, text):
         """
         Updates the stacked widget view handling the constraints inputs
@@ -401,21 +401,21 @@ class ViewFilter(QWidget):
             elif isinstance(item, Color3f):
                 self.stackedWidget.setCurrentIndex(3)
 
-    @pyqtSlot(str, name='le_point_2x')
+    @Slot(str, name='le_point_2x')
     def le_point_2x(self, text):
         if self.cbPoint2.isChecked():
             self.leExpY.blockSignals(True)
             self.leExpY.setText(text)
             self.leExpY.blockSignals(False)
 
-    @pyqtSlot(str, name='le_point_2y')
+    @Slot(str, name='le_point_2y')
     def le_point_2y(self, text):
         if self.cbPoint2.isChecked():
             self.leExpX.blockSignals(True)
             self.leExpX.setText(text)
             self.leExpX.blockSignals(False)
 
-    @pyqtSlot(str, name='le_point_3x')
+    @Slot(str, name='le_point_3x')
     def le_point_3x(self, text):
         if self.cbPoint3.isChecked():
             self.leExpY_2.blockSignals(True)
@@ -425,7 +425,7 @@ class ViewFilter(QWidget):
             self.leExpY_2.blockSignals(False)
             self.leExpZ.blockSignals(False)
 
-    @pyqtSlot(str, name='le_point_3y')
+    @Slot(str, name='le_point_3y')
     def le_point_3y(self, text):
         if self.cbPoint3.isChecked():
             self.leExpX_2.blockSignals(True)
@@ -435,7 +435,7 @@ class ViewFilter(QWidget):
             self.leExpX_2.blockSignals(False)
             self.leExpZ.blockSignals(False)
 
-    @pyqtSlot(str, name='le_point_3z')
+    @Slot(str, name='le_point_3z')
     def le_point_3z(self, text):
         if self.cbPoint3.isChecked():
             self.leExpX_2.blockSignals(True)
@@ -445,7 +445,7 @@ class ViewFilter(QWidget):
             self.leExpX_2.blockSignals(False)
             self.leExpY_2.blockSignals(False)
 
-    @pyqtSlot(str, name='le_color_r')
+    @Slot(str, name='le_color_r')
     def le_color_r(self, text):
         if self.cbColor.isChecked():
             self.leExpG.blockSignals(True)
@@ -455,7 +455,7 @@ class ViewFilter(QWidget):
             self.leExpG.blockSignals(False)
             self.leExpB.blockSignals(False)
 
-    @pyqtSlot(str, name='le_color_g')
+    @Slot(str, name='le_color_g')
     def le_color_g(self, text):
         if self.cbColor.isChecked():
             self.leExpR.blockSignals(True)
@@ -465,7 +465,7 @@ class ViewFilter(QWidget):
             self.leExpR.blockSignals(False)
             self.leExpB.blockSignals(False)
 
-    @pyqtSlot(str, name='le_color_b')
+    @Slot(str, name='le_color_b')
     def le_color_b(self, text):
         if self.cbColor.isChecked():
             self.leExpR.blockSignals(True)
@@ -475,7 +475,7 @@ class ViewFilter(QWidget):
             self.leExpR.blockSignals(False)
             self.leExpG.blockSignals(False)
 
-    @pyqtSlot(bool, name='clear_filter')
+    @Slot(bool, name='clear_filter')
     def clear_filter(self, clicked):
         """
         Informs the controller to clear all filters
@@ -484,7 +484,7 @@ class ViewFilter(QWidget):
         """
         self._controller.clear_filter()
 
-    @pyqtSlot(bool, name='delete_filter')
+    @Slot(bool, name='delete_filter')
     def delete_filter(self, clicked):
         """
         Deletes a filter from the view and informs the controller to delete the filter
@@ -496,7 +496,7 @@ class ViewFilter(QWidget):
             if item:
                 self._controller.delete_filter(item)
 
-    @pyqtSlot(int, name='state_changed')
+    @Slot(int, name='state_changed')
     def state_changed(self, state):
         if state != Qt.Checked:
             return
@@ -510,7 +510,7 @@ class ViewFilter(QWidget):
             self.leExpG.setText(self.leExpR.text())
             self.leExpB.setText(self.leExpR.text())
 
-    @pyqtSlot(bool, name='add_filter')
+    @Slot(bool, name='add_filter')
     def add_filter(self, clicked):
         """
         Informs the controller to add a filter to the filter list view
@@ -522,7 +522,7 @@ class ViewFilter(QWidget):
             fs = FilterSettings(self)
             self._controller.add_filter(fs)
 
-    @pyqtSlot(bool, name='apply_filters')
+    @Slot(bool, name='apply_filters')
     def apply_filters(self, clicked):
         """
         Informs the controller to apply the filter

--- a/View/MainView/view_options.py
+++ b/View/MainView/view_options.py
@@ -22,11 +22,11 @@
     SOFTWARE.
 """
 
-from PyQt5 import uic
-from PyQt5.Qt import Qt
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QApplication
+from Core.pyside2_uic import loadUi
+from PySide2.QtCore import Qt
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QApplication
 import os
 import logging
 
@@ -41,7 +41,7 @@ class ViewOptions(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=None)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'options.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._controller = None
 
@@ -95,7 +95,7 @@ class ViewOptions(QWidget):
     def set_auto_image_load(self, enabled):
         self.cbAutoLoadImage.setChecked(enabled)
 
-    @pyqtSlot(int, name='handle_dark_theme_change')
+    @Slot(int, name='handle_dark_theme_change')
     def handle_dark_theme_change(self, state):
         self.cbDarkTheme.blockSignals(True)
         if state == Qt.Checked:
@@ -110,7 +110,7 @@ class ViewOptions(QWidget):
             self.cbLightTheme.blockSignals(False)
         self.cbDarkTheme.blockSignals(False)
 
-    @pyqtSlot(int, name='handle_light_theme_change')
+    @Slot(int, name='handle_light_theme_change')
     def handle_light_theme_change(self, state):
         self.cbLightTheme.blockSignals(True)
         if state == Qt.Checked:
@@ -125,7 +125,7 @@ class ViewOptions(QWidget):
             self.cbDarkTheme.blockSignals(False)
         self.cbLightTheme.blockSignals(False)
 
-    @pyqtSlot(bool, name='btn_save')
+    @Slot(bool, name='btn_save')
     def btn_save(self, clicked):
         options_dict = {'theme': self.get_theme(),
                         'auto_connect': self.get_auto_connect(),
@@ -133,7 +133,7 @@ class ViewOptions(QWidget):
                         'auto_rendered_image_load': self.get_auto_image_load()}
         self._controller.save_options(options_dict)
 
-    @pyqtSlot(bool, name='btn_close')
+    @Slot(bool, name='btn_close')
     def btn_close(self, clicked):
         self.close()
 

--- a/View/MainView/view_render_info.py
+++ b/View/MainView/view_render_info.py
@@ -22,11 +22,11 @@
     SOFTWARE.
 """
 
-from PyQt5 import uic
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.Qt import Qt
+from Core.pyside2_uic import loadUi
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QApplication
+from PySide2.QtCore import Slot
+from PySide2.QtCore import Qt
 import os
 
 
@@ -40,7 +40,7 @@ class ViewRenderInfo(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=None)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'render_info.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._controller = None
 
@@ -81,7 +81,7 @@ class ViewRenderInfo(QWidget):
         if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
             self.btn_submit(True)
 
-    @pyqtSlot(int, name='sb_update_sample_count')
+    @Slot(int, name='sb_update_sample_count')
     def sb_update_sample_count(self, value):
         """
         Informs the controller to update the sample count of render info
@@ -90,7 +90,7 @@ class ViewRenderInfo(QWidget):
         """
         self._controller.update_render_info_sample_count(value)
 
-    @pyqtSlot(bool, name='btn_submit')
+    @Slot(bool, name='btn_submit')
     def btn_submit(self, clicked):
         """
         Informs the controller to submit render info and inform the server
@@ -99,7 +99,7 @@ class ViewRenderInfo(QWidget):
         """
         self._controller.send_render_info()
 
-    @pyqtSlot(bool, name='btn_close')
+    @Slot(bool, name='btn_close')
     def btn_close(self, clicked):
         self.close()
 

--- a/View/RenderView/hdr_graphics_view.py
+++ b/View/RenderView/hdr_graphics_view.py
@@ -23,7 +23,7 @@
 """
 
 from Core.hdr_graphics_view_base import HDRGraphicsViewBase
-from PyQt5.QtCore import QPoint
+from PySide2.QtCore import QPoint
 import logging
 
 

--- a/View/RenderView/view_render_image.py
+++ b/View/RenderView/view_render_image.py
@@ -23,9 +23,9 @@
 """
 
 from View.RenderView.hdr_graphics_view import HDRGraphicsView
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtCore import pyqtSlot
-from PyQt5 import uic
+from PySide2.QtWidgets import QWidget
+from PySide2.QtCore import Slot
+from Core.pyside2_uic import loadUi
 import math
 import os
 import logging
@@ -43,7 +43,7 @@ class ViewRenderImage(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=parent)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'render_image.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         # accept drops for drag n drop feature
         self.setAcceptDrops(True)
@@ -70,7 +70,7 @@ class ViewRenderImage(QWidget):
         """
         return self._graphics_view.pixmap
 
-    @pyqtSlot(float, name='set_slider_value')
+    @Slot(float, name='set_slider_value')
     def set_slider_value(self, value):
         """
         Sets the slider value of the exposure
@@ -85,7 +85,7 @@ class ViewRenderImage(QWidget):
         self.hsExposure.setValue(new_value)
         self.update_exposure(float(value))
 
-    @pyqtSlot(int, name='set_spin_value')
+    @Slot(int, name='set_spin_value')
     def set_spin_value(self, value):
         """
         Sets the spin value of the exposure
@@ -149,7 +149,7 @@ class ViewRenderImage(QWidget):
             if isinstance(hdr_image.filepath, str):
                 self._controller.save_options({'rendered_image_filepath': hdr_image.filepath})
 
-    @pyqtSlot(bool, name='reset')
+    @Slot(bool, name='reset')
     def reset(self, clicked):
         """
         Resets the exposure settings, and fits the render image within the view
@@ -159,7 +159,7 @@ class ViewRenderImage(QWidget):
         self._graphics_view.reset()
         self.hsExposure.setValue(0)
 
-    @pyqtSlot(bool, name='load_image_dialog')
+    @Slot(bool, name='load_image_dialog')
     def load_image_dialog(self, clicked):
         """
         Informs the controller to open a dialog to load an image from a given filepath

--- a/View/SampleContributionView/view_sample_contribution_plot.py
+++ b/View/SampleContributionView/view_sample_contribution_plot.py
@@ -23,9 +23,8 @@
 """
 
 from View.SampleContributionView.sample_contribution_plot import SampleContributionPlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QVBoxLayout
-from PyQt5.QtCore import Qt
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QVBoxLayout
 import logging
 
 

--- a/View/SceneView/view_render_scene.py
+++ b/View/SceneView/view_render_scene.py
@@ -25,10 +25,10 @@
 from Core.messages import ViewMode
 from View.SceneView.view_render_scene_options import ViewRenderSceneOptions
 from Renderer.renderer import Renderer
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QFileDialog
-from PyQt5 import uic
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QFileDialog
+from Core.pyside2_uic import loadUi
 import os
 import logging
 
@@ -43,7 +43,7 @@ class ViewRenderScene(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent=parent)
         ui_filepath = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'ui', 'render_scene.ui'))
-        uic.loadUi(ui_filepath, self)
+        loadUi(ui_filepath, self)
 
         self._controller = None
 
@@ -79,7 +79,7 @@ class ViewRenderScene(QWidget):
         """
         self._controller = controller
 
-    @pyqtSlot(bool, name='open_view_render_options')
+    @Slot(bool, name='open_view_render_options')
     def open_view_render_options(self, clicked):
         """
         Opens the view render options
@@ -91,7 +91,7 @@ class ViewRenderScene(QWidget):
         else:
             self._view_render_options.show()
 
-    @pyqtSlot(bool, name='load_scene')
+    @Slot(bool, name='load_scene')
     def request_scene(self, clicked):
         """
         Informs the controller to request the 3D scene data from the server
@@ -101,7 +101,7 @@ class ViewRenderScene(QWidget):
         self._renderer.clear_scene_objects()
         self._controller.request_scene_data()
 
-    @pyqtSlot(bool, name='reset')
+    @Slot(bool, name='reset')
     def reset(self, clicked):
         """
         Informs the renderer to reset the scenes camera view
@@ -110,7 +110,7 @@ class ViewRenderScene(QWidget):
         """
         self._renderer.reset_scene()
 
-    @pyqtSlot(bool, name='screenshot')
+    @Slot(bool, name='screenshot')
     def screenshot(self, clicked):
         """
         Informs the renderer to take a screenshot of the view and save it under the given filename

--- a/View/SceneView/view_render_scene_options.py
+++ b/View/SceneView/view_render_scene_options.py
@@ -22,10 +22,10 @@
     SOFTWARE.
 """
 
-from PyQt5 import uic
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtWidgets import QWidget
-from PyQt5.QtWidgets import QApplication
+from Core.pyside2_uic import loadUi
+from PySide2.QtCore import Slot
+from PySide2.QtWidgets import QWidget
+from PySide2.QtWidgets import QApplication
 import logging
 
 
@@ -69,7 +69,7 @@ class ViewRenderSceneOptions(QWidget):
 
     def __init__(self):
         QWidget.__init__(self, parent=None)
-        uic.loadUi('View/ui/render_scene_options.ui', self)
+        loadUi('View/ui/render_scene_options.ui', self)
 
         self._renderer = None
 
@@ -257,7 +257,7 @@ class ViewRenderSceneOptions(QWidget):
         self.sliderVertexSize.setValue(size)
         self.sliderVertexSize.blockSignals(False)
 
-    @pyqtSlot(bool, name='show_all_nees')
+    @Slot(bool, name='show_all_nees')
     def show_all_nees(self, state):
         """
         Informs the renderer to show all next event estimations
@@ -269,7 +269,7 @@ class ViewRenderSceneOptions(QWidget):
         self.cbShowNEERays.blockSignals(False)
         self._renderer.show_all_nees(state)
 
-    @pyqtSlot(bool, name='show_all_paths')
+    @Slot(bool, name='show_all_paths')
     def show_all_paths(self, state):
         """
         Informs the renderer to show all traced paths
@@ -282,7 +282,7 @@ class ViewRenderSceneOptions(QWidget):
             self.cbShowPathRays.blockSignals(False)
         self._renderer.show_all_paths(state)
 
-    @pyqtSlot(bool, name='show_all_verts')
+    @Slot(bool, name='show_all_verts')
     def show_all_verts(self, state):
         """
         Informs the renderer to show all vertices
@@ -291,7 +291,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.show_all_verts(state)
 
-    @pyqtSlot(int, name='update_camera_motion_speed')
+    @Slot(int, name='update_camera_motion_speed')
     def update_camera_motion_speed(self, speed):
         """
         Informs the renderer to update the camera motion speed
@@ -300,7 +300,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.update_camera_motion_speed(speed)
 
-    @pyqtSlot(bool, name='update_camera_clipping')
+    @Slot(bool, name='update_camera_clipping')
     def update_camera_clipping(self, state):
         """
         Informs the renderer to update camera clipping
@@ -309,7 +309,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.update_camera_clipping(state)
 
-    @pyqtSlot(bool, name='reset_camera_options')
+    @Slot(bool, name='reset_camera_options')
     def reset_camera_options(self, clicked):
         """
         Inform the renderer to reset the camera settings
@@ -319,7 +319,7 @@ class ViewRenderSceneOptions(QWidget):
         self._renderer.reset_camera_motion_speed()
         self.load_camera_settings()
 
-    @pyqtSlot(int, name='update_scene_opacity')
+    @Slot(int, name='update_scene_opacity')
     def update_scene_opacity(self, opacity):
         """
         Informs the renderer to update the scene opacity
@@ -329,7 +329,7 @@ class ViewRenderSceneOptions(QWidget):
         max_value = self.sliderMeshOpacity.maximum()
         self._renderer.update_scene_opacity(float(opacity / max_value))
 
-    @pyqtSlot(bool, name='reset_scene_opacity')
+    @Slot(bool, name='reset_scene_opacity')
     def reset_scene_opacity(self, clicked):
         """
         Informs the renderer to reset the scenes opacity
@@ -339,7 +339,7 @@ class ViewRenderSceneOptions(QWidget):
         self._renderer.reset_scene_opacity()
         self.load_scene_settings()
 
-    @pyqtSlot(int, name='update_path_opacity')
+    @Slot(int, name='update_path_opacity')
     def update_path_opacity(self, opacity):
         """
         Informs the renderer to update the path opacity
@@ -349,7 +349,7 @@ class ViewRenderSceneOptions(QWidget):
         max_value = self.sliderPathOpacity.maximum()
         self._renderer.update_path_opacity(float(opacity / max_value))
 
-    @pyqtSlot(int, name='update_path_size')
+    @Slot(int, name='update_path_size')
     def update_path_size(self, size):
         """
         Informs the renderer to update the path size
@@ -358,7 +358,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.update_path_size(size)
 
-    @pyqtSlot(bool, name='reset_path')
+    @Slot(bool, name='reset_path')
     def reset_path(self, clicked):
         """
         Informs the renderer to reset the paths size and opacity
@@ -368,7 +368,7 @@ class ViewRenderSceneOptions(QWidget):
         self._renderer.reset_path()
         self.load_path_settings()
 
-    @pyqtSlot(bool, name='show_traced_path')
+    @Slot(bool, name='show_traced_path')
     def show_traced_path(self, state):
         """
         Informs the renderer to show all traced paths
@@ -381,7 +381,7 @@ class ViewRenderSceneOptions(QWidget):
         self.cbShowOmegaI.setChecked(state)
         self.cbShowOmegaI.blockSignals(False)
 
-    @pyqtSlot(bool, name='show_traced_path_nee')
+    @Slot(bool, name='show_traced_path_nee')
     def show_traced_path_nee(self, state):
         """
         Informs the renderer to show paths next event estimations
@@ -394,7 +394,7 @@ class ViewRenderSceneOptions(QWidget):
         self.cbShowNEE.setChecked(state)
         self.cbShowNEE.blockSignals(False)
 
-    @pyqtSlot(bool, name='show_other_paths')
+    @Slot(bool, name='show_other_paths')
     def show_other_paths(self, state):
         """
         Informs the renderer to show all other traced paths besides the current selected one
@@ -403,7 +403,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.show_other_paths(state)
 
-    @pyqtSlot(int, name='update_vertex_opacity')
+    @Slot(int, name='update_vertex_opacity')
     def update_vertex_opacity(self, opacity):
         """
         Informs the renderer to update the vertex opacity of the current selected vertex
@@ -413,7 +413,7 @@ class ViewRenderSceneOptions(QWidget):
         max_value = self.sliderVertexOpacity.maximum()
         self._renderer.update_vertex_opacity(float(opacity / max_value))
 
-    @pyqtSlot(int, name='update_vertex_size')
+    @Slot(int, name='update_vertex_size')
     def update_vertex_size(self, size):
         """
         Informs the renderer to update the vertex size of the current selected vertex
@@ -422,7 +422,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.update_vertex_size(size)
 
-    @pyqtSlot(bool, name='reset_vertex')
+    @Slot(bool, name='reset_vertex')
     def reset_vertex(self, clicked):
         """
         Informs the renderer to reset the vertex opacity and size
@@ -432,7 +432,7 @@ class ViewRenderSceneOptions(QWidget):
         self._renderer.reset_vertex()
         self.load_vertex_settings()
 
-    @pyqtSlot(bool, name='show_vertex_omega_i')
+    @Slot(bool, name='show_vertex_omega_i')
     def show_vertex_omega_i(self, state):
         """
         Informs the renderer to visualize the incoming ray of the current selected vertex,
@@ -442,7 +442,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.show_vertex_omega_i(state)
 
-    @pyqtSlot(bool, name='show_vertex_omega_o')
+    @Slot(bool, name='show_vertex_omega_o')
     def show_vertex_omega_o(self, state):
         """
         Informs the renderer to visualize the outgoing ray of the current selected vertex,
@@ -452,7 +452,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.show_vertex_omega_o(state)
 
-    @pyqtSlot(bool, name='show_vertex_nee')
+    @Slot(bool, name='show_vertex_nee')
     def show_vertex_nee(self, state):
         """
         Informs the renderer to visualize the next event estimation of the current selected vertex,
@@ -462,7 +462,7 @@ class ViewRenderSceneOptions(QWidget):
         """
         self._renderer.show_vertex_nee(state)
 
-    @pyqtSlot(bool, name='show_other_verts')
+    @Slot(bool, name='show_other_verts')
     def show_other_verts(self, state):
         """
         Informs the renderer to visualize all other vertices besides the current visible ones,

--- a/emca.py
+++ b/emca.py
@@ -22,8 +22,8 @@
     SOFTWARE.
 """
 
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import QFile, QTextStream
+from PySide2.QtWidgets import QApplication
+from PySide2.QtCore import QFile, QTextStream
 from Core.logger import InitLogSystem
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ six==1.11.0
 scipy==1.1.0
 matplotlib==3.2.1
 OpenEXR==1.3.2
-Pillow==5.1.0
-PyQt5==5.14
-vtk==8.1.1
+Pillow==7.1.2
+PySide2==5.14.2.1
+vtk==9.0.0
 


### PR DESCRIPTION
All dependencies to PyQt5 which only offers the GPL license have been removed. Officially moved everything to Pyside2 (5.14.2.1) which allows the LGPL license in addition to the GPL license. Furthermore Pyside2 is officially promoted and supported by Qt.

To support Pyside2 the Pilllow (5.1.2 -> 7.1.2) and VTK (8.1.2 -> 9.0.0) framework has been updated.

Since Pyside2 does not provide a "uic" loader, the class itself was defined and added to the core.